### PR TITLE
Changes to remove redundancies with other STAC extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This document explains the MLHub Extension to the [SpatioTemporal Asset Catalog]
 - [JSON Schema](json-schema/schema.json)
 - [Changelog](./CHANGELOG.md)
 
-
 ## Catalog Fields
 
 For Catalogs, the fields are placed on the top level of the Catalog.
@@ -29,7 +28,6 @@ For Catalogs, the fields are placed on the top level of the Catalog.
 | mlhub:tools_apps       | \[[ExternalResource](#externalresource-object)]  | List of the tools and applications used in dataset generation     |
 | mlhub:tutorials        | \[[ExternalResource](#externalresource-object)]  | List of tutorials such as jupyter notebooks or github repos       |
 
-
 ### CreatorContact Object
 
 This object provides reference to the primary point of contact for the dataset and their organizational affiliation, e.g. their email and name of research institution. Each value in both the `contact` and `creator` fields are strings, but both can also be single comma delineated strings to add more contact and creator details.
@@ -39,16 +37,13 @@ This object provides reference to the primary point of contact for the dataset a
 | contact     | string | **REQUIRED**. Email address(es) of the primary points of contact    |
 | creator     | string | **REQUIRED**. Name and URL of affiliated institutions (in markdown) |
 
-
 ### Dataset Tags/Keywords
 
 Tags are a list of keywords added to the dataset's metadata to describe or categorize the catalog, combining one or more words, that improve the user experience by allowing them to filter all the datasets seen on Radiant MLHub catalog to a speicif subset of types, e.g. satellite constellation, machine learning use-case, or data provider.
 
-
 ### Dataset Created and Updated Dates
 
 In addition to the `datetime` properties required by the STAC specification for Collections and Items, such as `datetime`, `start_datetime` and `end_datetime` as well as the `interval` values of `extent`, we need to capture the date that the dataset was added to Radiant MLHub and the most recent date that a dataset was updated. Therefore, we will use two additional fields as part of the [STAC Common Metadata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md), `created` and `updated`. These two fields will follow the same formatting convention as other datetime objects in the STAC specification. All times in STAC metadata should be in [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to [RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
-
 
 ### ScienceKeyword Object
 
@@ -68,7 +63,6 @@ Earth Science Keywords have six-level hierarchical keyword structure with the op
 
 NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
 
-
 ### LocationKeyword Object
 
 The Location Keywords element contains keywords that characterize the study area/region where data was collected. This allows users to narrow their searches to areas that suit their geographic interest. The Location Keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://wiki.earthdata.nasa.gov/display/gcmdkey/Keyword+Management+Service+Application+Program+Interface). A list of valid Location Keywords can be found [here](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations?format=csv).
@@ -86,7 +80,6 @@ Location Keywords have a five-level hierarchical keyword structure with the opti
 
 NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
 
-
 ### ExternalResource Object
 
 This is a more abstract object describes an external resource that is somehow relevant to the dataset being published. This object is used by the `publications`, `tutorials`, and `tools and applications` fields, as they all share the same key/value pairs of nested attributes.
@@ -98,7 +91,6 @@ This is a more abstract object describes an external resource that is somehow re
 | author_url   | string | Webpage or social media account of the author(s)                       |
 | author_name  | string | Name(s) of the author(s) who created the external resource referrenced |
 
-
 ## Contributing
 
 All contributions are subject to the
@@ -106,7 +98,6 @@ All contributions are subject to the
 For contributions, please follow the
 [STAC specification contributing guide](https://github.com/radiantearth/stac-spec/blob/master/CONTRIBUTING.md) Instructions
 for running tests are copied here for convenience.
-
 
 ### Running tests
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ fields will follow the same formatting convention as other datetime objects in t
 [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to 
 [RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 
-### Collection Progress
-
-Describes the production status of a dataset using five possible categories: `PLANNED`, `ACTIVE`, `COMPLETE`, `DEPRECATED` and `NOT APPLICABLE`.
-
-[GMCD Collection Progress Specification](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress)
-
 ### ScienceKeyword Object
 
 The Science Keywords element allows relevant Earth science keywords to be associated with a dataset to better enable data search and discovery. The

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ For Catalogs, the fields are placed on the top level of the Catalog.
 | Field Name             | Type                                             | Description                                                       |
 | ---------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
 | mlhub:creator_contact  | [CreatorContact](#creatorcontact-object)         | **REQUIRED**. The primary creator and point of contact            |
-| mlhub:tags             | \[string]                                        | **REQUIRED**. List of keywords to populate the webpage tag filter |
-| mlhub:date_added       | string                                           | **REQUIRED**. Datetime for when the dataset was added to MLHub    |
-| mlhub:date_modified    | string                                           | **REQUIRED**. Datetime for the last time dataset was modified     |
-| mlhub:processing_level | number                                           | **REQUIRED**. Identifier indicating the level at which the data in the collection are processed ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Processing+Level)) |
 | mlhub:collection_progress | string                                        | **REQUIRED**. Describes the production status of the dataset ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress))      |
 | mlhub:science_keywords | \[[ScienceKeyword](#sciencekeyword-object)]      | **REQUIRED**. Allows relevant Earth science keywords to be associated with a dataset to better enable data search and discovery ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Science+Keywords)) |
 | mlhub:location_keywords | \[[LocationKeyword](#locationkeyword-object)]   | Contain keywords that characterize the study area/region where the data was collected ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Location+Keywords)) |
@@ -44,14 +40,14 @@ This object provides reference to the primary point of contact for the dataset a
 | creator     | string | **REQUIRED**. Name and URL of affiliated institutions (in markdown) |
 
 
-### Dataset Tags
+### Dataset Tags/Keywords
 
 Tags are a list of keywords added to the dataset's metadata to describe or categorize the catalog, combining one or more words, that improve the user experience by allowing them to filter all the datasets seen on Radiant MLHub catalog to a speicif subset of types, e.g. satellite constellation, machine learning use-case, or data provider.
 
 
-### Dataset Added and Modified Dates
+### Dataset Created and Updated Dates
 
-In addition to the `datetime` properties required by the STAC specification for Collections and Items, such as `datetime`, `start_datetime` and `end_datetime` as well as the `interval` values of `extent`, we need to capture the date that the dataset was added to Radiant MLHub and the most recent date that a dataset was updated. Therefore, this extension will contain two additional fields, `date_added` and `date_modified`. These two fields will follow the same formatting convention as other datetime objects in the STAC specification. All times in STAC metadata should be in [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to [RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+In addition to the `datetime` properties required by the STAC specification for Collections and Items, such as `datetime`, `start_datetime` and `end_datetime` as well as the `interval` values of `extent`, we need to capture the date that the dataset was added to Radiant MLHub and the most recent date that a dataset was updated. Therefore, we will use two additional fields as part of the [STAC Common Metadata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md), `created` and `updated`. These two fields will follow the same formatting convention as other datetime objects in the STAC specification. All times in STAC metadata should be in [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to [RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 
 ### ScienceKeyword Object

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ fields will follow the same formatting convention as other datetime objects in t
 
 ### Collection Progress
 
+Describes the production status of a dataset using five possible categories: `PLANNED`, `ACTIVE`, `COMPLETE`, `DEPRECATED` and `NOT APPLICABLE`.
+
 [GMCD Collection Progress Specification](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress)
 
 ### ScienceKeyword Object
@@ -74,19 +76,15 @@ of valid Science Keywords can be found [here](https://gcmd.earthdata.nasa.gov/km
 Earth Science Keywords have six-level hierarchical keyword structure with the option for a seventh uncontrolled field. This hierarchical structure
 provides a framework by which concepts can be classified and related. Category and Topic levels define how the keywords are organized and the
 associated Earth science discipline within the hierarchy. The Term and Variables levels define the subject area, measured variables/parameters, and
-the hierarchical-type relationship for the subject area.
+the hierarchical-type relationship for the subject area. Using the UUID, we are able to query and reconstruct the six-level hierarchy by choosing 
+to store only the lowest level `name` and `uuid` relationship from within the GCMD Earth Science Keyword specification.
 
 [GMCD Earth Science Keyword Specification](https://wiki.earthdata.nasa.gov/display/CMR/Science+Keywords)
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |
-| category     | string | **REQUIRED**. Defines disciplines and high level concepts |
-| topic        | string | **REQUIRED**. Defines disciplines and high level concepts |
-| term         | string | **REQUIRED**. Define subject areas and parameters |
-| variable_level_1 | string | Define subject areas and parameters |
-| variable_level_2 | string | Define subject areas and parameters |
-| variable_level_2 | string | Define subject areas and parameters |
-| detailed_variable | string | Uncontrolled values that can be added by users to more specifically describe data |
+| name     | string | **REQUIRED**. The human readable lowest level Earth Science Keyword chosen per specification |
+| uuid     | string | **REQUIRED**. UUID of the name property for lowest level of Earth Science Keyword chosen |
 
 NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the 
 [Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
@@ -103,6 +101,11 @@ on Earth, a location within Earth, a vertical location, or a location outside of
 which concepts can be classified and related. 
 
 [GMCD Location Keyword Specification](https://wiki.earthdata.nasa.gov/display/CMR/Location+Keywords)
+
+For example, with LandCoverNet Africa v1.0 (`ref_landcovernet_af_v1`), the most granular geographic scope reasonable to capture is the entire 
+contient of Africa, as the dataset is spread sparsely across the continent. However there are some datasets which are specific to a state or 
+certain region within a country. Under the circumstances, it is appropriate to choose a more granular level of location keywords per the 
+specification.
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
 - **Owner**: @KennSmithDS
 
-This document explains the MLHub Extension to the [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification. An MLHub Extension is a STAC **Catalog**, in that it contains multiple children **Collection** and related **Item** STAC objects. However, the use-case is specific to when a datset is published onto the Radiant MLHub web page and API. There are additional metadata properties which are stored in the Catalog which are then used to construct a complete row for insertion into the `mlhub.dataset` table in our private PostgreSQL database on the MLHub back-end. These properties in the database are then parsed by the front-end and rendered in HTML. They are properties specific to Radiant MLHub's dataset publishing workflow only.
+This document explains the MLHub Extension to the [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification.
+An MLHub Extension is a STAC **Catalog**, in that it contains multiple children **Collection** and related **Item** STAC objects. However, the
+use-case is specific to when a datset is published onto the Radiant MLHub web page and API. There are additional metadata properties which are
+stored in the Catalog which are then used to construct a complete row for insertion into the `mlhub.dataset` table in our private PostgreSQL
+database on the MLHub back-end. These properties in the database are then parsed by the front-end and rendered in HTML. They are properties
+specific to Radiant MLHub's dataset publishing workflow only.
 
 - Examples:
   - [Catalog example](examples/catalog.json): Shows the basic usage of the extension in a STAC Catalog
@@ -21,16 +26,21 @@ For Catalogs, the fields are placed on the top level of the Catalog.
 | Field Name             | Type                                             | Description                                                       |
 | ---------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
 | mlhub:creator_contact  | [CreatorContact](#creatorcontact-object)         | **REQUIRED**. The primary creator and point of contact            |
-| mlhub:collection_progress | string                                        | **REQUIRED**. Describes the production status of the dataset ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress))      |
-| mlhub:science_keywords | \[[ScienceKeyword](#sciencekeyword-object)]      | **REQUIRED**. Allows relevant Earth science keywords to be associated with a dataset to better enable data search and discovery ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Science+Keywords)) |
-| mlhub:location_keywords | \[[LocationKeyword](#locationkeyword-object)]   | Contain keywords that characterize the study area/region where the data was collected ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Location+Keywords)) |
+| mlhub:collection_progress | string                                        | **REQUIRED**. Describes the production status of the dataset 
+([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress))      |
+| mlhub:science_keywords | \[[ScienceKeyword](#sciencekeyword-object)]      | **REQUIRED**. Allows relevant Earth science keywords to be associated
+with a dataset to better enable data search and discovery ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Science+Keywords)) |
+| mlhub:location_keywords | \[[LocationKeyword](#locationkeyword-object)]   | Contain keywords that characterize the study area/region where the
+data was collected ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Location+Keywords)) |
 | mlhub:publications     | \[[ExternalResource](#externalresource-object)]  | List of the publications associated with the dataset              |
 | mlhub:tools_apps       | \[[ExternalResource](#externalresource-object)]  | List of the tools and applications used in dataset generation     |
 | mlhub:tutorials        | \[[ExternalResource](#externalresource-object)]  | List of tutorials such as jupyter notebooks or github repos       |
 
 ### CreatorContact Object
 
-This object provides reference to the primary point of contact for the dataset and their organizational affiliation, e.g. their email and name of research institution. Each value in both the `contact` and `creator` fields are strings, but both can also be single comma delineated strings to add more contact and creator details.
+This object provides reference to the primary point of contact for the dataset and their organizational affiliation, e.g. their email and name of
+research institution. Each value in both the `contact` and `creator` fields are strings, but both can also be single comma delineated strings to
+add more contact and creator details.
 
 | Field Name  | Type   | Description                                                         |
 | ----------- | ------ | ------------------------------------------------------------------- |
@@ -39,17 +49,31 @@ This object provides reference to the primary point of contact for the dataset a
 
 ### Dataset Tags/Keywords
 
-Tags are a list of keywords added to the dataset's metadata to describe or categorize the catalog, combining one or more words, that improve the user experience by allowing them to filter all the datasets seen on Radiant MLHub catalog to a speicif subset of types, e.g. satellite constellation, machine learning use-case, or data provider.
+Tags are a list of keywords added to the dataset's metadata to describe or categorize the catalog, combining one or more words, that improve the
+user experience by allowing them to filter all the datasets seen on Radiant MLHub catalog to a speicif subset of types, e.g. satellite constellation,
+machine learning use-case, or data provider.
 
 ### Dataset Created and Updated Dates
 
-In addition to the `datetime` properties required by the STAC specification for Collections and Items, such as `datetime`, `start_datetime` and `end_datetime` as well as the `interval` values of `extent`, we need to capture the date that the dataset was added to Radiant MLHub and the most recent date that a dataset was updated. Therefore, we will use two additional fields as part of the [STAC Common Metadata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md), `created` and `updated`. These two fields will follow the same formatting convention as other datetime objects in the STAC specification. All times in STAC metadata should be in [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to [RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+In addition to the `datetime` properties required by the STAC specification for Collections and Items, such as `datetime`, `start_datetime` and
+`end_datetime` as well as the `interval` values of `extent`, we need to capture the date that the dataset was added to Radiant MLHub and the most
+recent date that a dataset was updated. Therefore, we will use two additional fields as part of the 
+[STAC Common Metadata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md), `created` and `updated`. These two
+fields will follow the same formatting convention as other datetime objects in the STAC specification. All times in STAC metadata should be in 
+[Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to 
+[RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 ### ScienceKeyword Object
 
-The Science Keywords element allows relevant Earth science keywords to be associated with a dataset to better enable data search and discovery. The Science Keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://wiki.earthdata.nasa.gov/display/gcmdkey/Keyword+Management+Service+Application+Program+Interface). A list of valid Science Keywords can be found [here](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords?format=csv).
+The Science Keywords element allows relevant Earth science keywords to be associated with a dataset to better enable data search and discovery. The
+Science Keywords are chosen from a controlled keyword hierarchy maintained in the 
+[Keyword Management System (KMS)](https://wiki.earthdata.nasa.gov/display/gcmdkey/Keyword+Management+Service+Application+Program+Interface). A list
+of valid Science Keywords can be found [here](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords?format=csv).
 
-Earth Science Keywords have six-level hierarchical keyword structure with the option for a seventh uncontrolled field. This hierarchical structure provides a framework by which concepts can be classified and related. Category and Topic levels define how the keywords are organized and the associated Earth science discipline within the hierarchy. The Term and Variables levels define the subject area, measured variables/parameters, and the hierarchical-type relationship for the subject area.
+Earth Science Keywords have six-level hierarchical keyword structure with the option for a seventh uncontrolled field. This hierarchical structure
+provides a framework by which concepts can be classified and related. Category and Topic levels define how the keywords are organized and the
+associated Earth science discipline within the hierarchy. The Term and Variables levels define the subject area, measured variables/parameters, and
+the hierarchical-type relationship for the subject area.
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |
@@ -61,13 +85,19 @@ Earth Science Keywords have six-level hierarchical keyword structure with the op
 | variable_level_2 | string | Define subject areas and parameters |
 | detailed_variable | string | Uncontrolled values that can be added by users to more specifically describe data |
 
-NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
+NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the 
+[Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
 
 ### LocationKeyword Object
 
-The Location Keywords element contains keywords that characterize the study area/region where data was collected. This allows users to narrow their searches to areas that suit their geographic interest. The Location Keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://wiki.earthdata.nasa.gov/display/gcmdkey/Keyword+Management+Service+Application+Program+Interface). A list of valid Location Keywords can be found [here](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations?format=csv).
+The Location Keywords element contains keywords that characterize the study area/region where data was collected. This allows users to narrow their
+searches to areas that suit their geographic interest. The Location Keywords are chosen from a controlled keyword hierarchy maintained in the 
+[Keyword Management System (KMS)](https://wiki.earthdata.nasa.gov/display/gcmdkey/Keyword+Management+Service+Application+Program+Interface). A list
+of valid Location Keywords can be found [here](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations?format=csv).
 
-Location Keywords have a five-level hierarchical keyword structure with the option for a sixth uncontrolled field and define the name of a place on Earth, a location within Earth, a vertical location, or a location outside of the Earth.. This hierarchical structure provides a framework by which concepts can be classified and related. 
+Location Keywords have a five-level hierarchical keyword structure with the option for a sixth uncontrolled field and define the name of a place
+on Earth, a location within Earth, a vertical location, or a location outside of the Earth.. This hierarchical structure provides a framework by
+which concepts can be classified and related. 
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |
@@ -78,11 +108,13 @@ Location Keywords have a five-level hierarchical keyword structure with the opti
 | location_subregion_3  | string      | Most granular level of location e.g. a city or county within a country |
 | detailed_location     | string      | Uncontrolled values that can be added by users to more specifically describe location |
 
-NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the [Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
+NOTE: The complete list of keywords are chosen from a controlled keyword hierarchy maintained in the 
+[Keyword Management System (KMS)](https://earthdata.nasa.gov/earth-observation-data/find-data/idn/gcmd-keywords)
 
 ### ExternalResource Object
 
-This is a more abstract object describes an external resource that is somehow relevant to the dataset being published. This object is used by the `publications`, `tutorials`, and `tools and applications` fields, as they all share the same key/value pairs of nested attributes.
+This is a more abstract object describes an external resource that is somehow relevant to the dataset being published. This object is used by
+the `publications`, `tutorials`, and `tools and applications` fields, as they all share the same key/value pairs of nested attributes.
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |

--- a/README.md
+++ b/README.md
@@ -26,12 +26,9 @@ For Catalogs, the fields are placed on the top level of the Catalog.
 | Field Name             | Type                                             | Description                                                       |
 | ---------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
 | mlhub:creator_contact  | [CreatorContact](#creatorcontact-object)         | **REQUIRED**. The primary creator and point of contact            |
-| mlhub:collection_progress | string                                        | **REQUIRED**. Describes the production status of the dataset 
-([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress))      |
-| mlhub:science_keywords | \[[ScienceKeyword](#sciencekeyword-object)]      | **REQUIRED**. Allows relevant Earth science keywords to be associated
-with a dataset to better enable data search and discovery ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Science+Keywords)) |
-| mlhub:location_keywords | \[[LocationKeyword](#locationkeyword-object)]   | Contain keywords that characterize the study area/region where the
-data was collected ([GMCD Keyword Spec](https://wiki.earthdata.nasa.gov/display/CMR/Location+Keywords)) |
+| mlhub:collection_progress | string                                        | **REQUIRED**. Describes the production status of the dataset      |
+| mlhub:science_keywords | \[[ScienceKeyword](#sciencekeyword-object)]      | **REQUIRED**. Allows for better data search and discovery         |
+| mlhub:location_keywords | \[[LocationKeyword](#locationkeyword-object)]   | The study area/region where the data was collected                |
 | mlhub:publications     | \[[ExternalResource](#externalresource-object)]  | List of the publications associated with the dataset              |
 | mlhub:tools_apps       | \[[ExternalResource](#externalresource-object)]  | List of the tools and applications used in dataset generation     |
 | mlhub:tutorials        | \[[ExternalResource](#externalresource-object)]  | List of tutorials such as jupyter notebooks or github repos       |
@@ -63,6 +60,10 @@ fields will follow the same formatting convention as other datetime objects in t
 [Coordinated Universal Time (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and be formatted according to 
 [RFC 3339 section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 
+### Collection Progress
+
+[GMCD Collection Progress Specification](https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress)
+
 ### ScienceKeyword Object
 
 The Science Keywords element allows relevant Earth science keywords to be associated with a dataset to better enable data search and discovery. The
@@ -74,6 +75,8 @@ Earth Science Keywords have six-level hierarchical keyword structure with the op
 provides a framework by which concepts can be classified and related. Category and Topic levels define how the keywords are organized and the
 associated Earth science discipline within the hierarchy. The Term and Variables levels define the subject area, measured variables/parameters, and
 the hierarchical-type relationship for the subject area.
+
+[GMCD Earth Science Keyword Specification](https://wiki.earthdata.nasa.gov/display/CMR/Science+Keywords)
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |
@@ -98,6 +101,8 @@ of valid Location Keywords can be found [here](https://gcmd.earthdata.nasa.gov/k
 Location Keywords have a five-level hierarchical keyword structure with the option for a sixth uncontrolled field and define the name of a place
 on Earth, a location within Earth, a vertical location, or a location outside of the Earth.. This hierarchical structure provides a framework by
 which concepts can be classified and related. 
+
+[GMCD Location Keyword Specification](https://wiki.earthdata.nasa.gov/display/CMR/Location+Keywords)
 
 | Field Name   | Type   | Description |
 | ------------ | ------ | ----------- |

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -26,8 +26,10 @@
         }
     ],
     "type": "Catalog",
-    "stac_extensions": ["https://raw.githubusercontent.com/radiantearth/mlhub-dataset/main/json-schema/schema.json"],
-    "mlhub:tags": ["land cover", "segmentation", "sentinel-2", "sentinel-1", "landsat 8"],
+    "stac_extensions": [
+        "https://raw.githubusercontent.com/radiantearth/mlhub-dataset/main/json-schema/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json"
+    ],
     "mlhub:creator_contact": {
         "contact": "ml@radiant.earth", 
         "creator": "[Radiant Earth Foundation](https://radiant.earth/)"
@@ -48,10 +50,17 @@
             "author_name": "Kevin Booth"
             }
         ],
-    "mlhub:processing_level": 3,
+    "processing:level": "3",
     "mlhub:collection_progress": "COMPLETE",
-    "mlhub:date_added": "2020-07-28T00:00:00Z",
-    "mlhub:date_modified": "2022-04-04T00:00:00Z",
+    "keywords": [
+        "land cover", 
+        "segmentation", 
+        "sentinel-2", 
+        "sentinel-1", 
+        "landsat 8"
+    ],
+    "created": "2020-07-28T00:00:00Z",
+    "updated": "2022-04-04T00:00:00Z",
     "mlhub:science_keywords": [
         {
             "category": "HUMAN DIMENSIONS",

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -27,8 +27,7 @@
     ],
     "type": "Catalog",
     "stac_extensions": [
-        "https://raw.githubusercontent.com/radiantearth/mlhub-dataset/main/json-schema/schema.json",
-        "https://stac-extensions.github.io/processing/v1.0.0/schema.json"
+        "https://raw.githubusercontent.com/radiantearth/mlhub-dataset/main/json-schema/schema.json"
     ],
     "mlhub:creator_contact": {
         "contact": "ml@radiant.earth", 
@@ -50,8 +49,6 @@
             "author_name": "Kevin Booth"
             }
         ],
-    "processing:level": "3",
-    "mlhub:collection_progress": "COMPLETE",
     "keywords": [
         "land cover", 
         "segmentation", 

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -10,19 +10,19 @@
         },
         {
             "rel": "child",
-            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/landcovernet_af_v1_source_sentinel_2/collection.json"
+            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/ref_landcovernet_af_v1_source_sentinel_2/collection.json"
         },
         {
             "rel": "child",
-            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/landcovernet_af_v1_source_sentinel_1/collection.json"
+            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/ref_landcovernet_af_v1_source_sentinel_1/collection.json"
         },
         {
             "rel": "child",
-            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/landcovernet_af_v1_source_landsat_8/collection.json"
+            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/ref_landcovernet_af_v1_source_landsat_8/collection.json"
         },
         {
             "rel": "child",
-            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/landcovernet_af_v1_labels/collection.json"
+            "href": "https://radiantmlhub.blob.core.windows.net/stac/landcovernet-af-v1/ref_landcovernet_af_v1_labels/collection.json"
         }
     ],
     "type": "Catalog",
@@ -63,10 +63,28 @@
     "updated": "2022-04-04T00:00:00Z",
     "mlhub:science_keywords": [
         {
-            "category": "HUMAN DIMENSIONS",
-            "topic": "ENVIRONMENTAL GOVERNANCE/MANAGEMENT",
-            "term": "LAND MANAGEMENT",
-            "variable_level_1": "LAND USE/LAND COVER CLASSIFICATION"
+            "name": "RASTER LABELS",
+            "uuid": "381a3ad7-64e9-464e-b5aa-c9ce0520546c"
+        },
+        {
+            "name": "RASTER SOURCE",
+            "uuid": "83eb2a9c-5f56-4512-94c1-acd084a5bf9d"
+        },
+        {
+            "name": "CLASSIFICATION",
+            "uuid": "ca240508-9cd7-400e-9420-ad96f72195bd"
+        },
+        {
+            "name": "SUPERVISED",
+            "uuid": "fdd890fa-377a-46ce-8fdc-2d7d16a461b7"
+        },
+        {
+            "name": "SEGMENTATION",
+            "uuid": "46b21df4-0467-48eb-b442-709b584ad816"
+        },
+        {
+            "name": "LAND USE/LAND COVER CLASSIFICATION",
+            "uuid": "75c312bc-79f9-4d74-a7c0-3c67c019196c"
         }
     ],
     "mlhub:location_keywords": [

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -57,11 +57,8 @@
       "allOf": [
         {"required": ["mlhub:tags"]},
         {"required": ["mlhub:creator_contact"]},
-        {"required": ["mlhub:date_added"]},
-        {"required": ["mlhub:date_modified"]},
         {"required": ["mlhub:science_keywords"]},
         {"required": ["mlhub:location_keywords"]},
-        {"required": ["mlhub:processing_level"]},
         {"required": ["mlhub:collection_progress"]}
       ]
     },
@@ -118,23 +115,6 @@
           "items": {
             "$ref": "#/definitions/location_keyword"
           }
-        },
-        "mlhub:date_added": {
-          "title": "Dataset Added Datetime",
-          "type": "string",
-          "format": "date-time",
-          "pattern": "(\\+00:00|Z)$"
-        },
-        "mlhub:date_modified": {
-          "title": "Dataset Modified Datetime",
-          "type": "string",
-          "format": "date-time",
-          "pattern": "(\\+00:00|Z)$"
-        },
-        "mlhub:processing_level": {
-          "title": "Processing Level",
-          "type": "number",
-          "const": 3
         },
         "mlhub:collection_progress": {
           "title": "Collection Progress",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -58,8 +58,7 @@
         {"required": ["mlhub:tags"]},
         {"required": ["mlhub:creator_contact"]},
         {"required": ["mlhub:science_keywords"]},
-        {"required": ["mlhub:location_keywords"]},
-        {"required": ["mlhub:collection_progress"]}
+        {"required": ["mlhub:location_keywords"]}
       ]
     },
     "fields": {
@@ -115,12 +114,6 @@
           "items": {
             "$ref": "#/definitions/location_keyword"
           }
-        },
-        "mlhub:collection_progress": {
-          "title": "Collection Progress",
-          "type": "string",
-          "minLength": 1,
-          "const": "COMPLETE"
         }
       },
       "patternProperties": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -147,36 +147,16 @@
       "title": "GMCD Earth Science Keyword",
       "type": "object",
       "properties": {
-        "category": {
-          "title": "Category",
+        "name": {
+          "title": "Name",
           "type": "string"
         },
-        "topic": {
-          "title": "Topic",
-          "type": "string"
-        },
-        "term": {
-          "title": "Term",
-          "type": "string"
-        },
-        "variable_level_1": {
-          "title": "Variable Level 1",
-          "type": "string"
-        },
-        "variable_level_2": {
-          "title": "Variable Level 2",
-          "type": "string"
-        },
-        "variable_level_3": {
-          "title": "Variable Level 3",
-          "type": "string"
-        },
-        "detailed_variable": {
-          "title": "Detailed Variable",
+        "uuid": {
+          "title": "UUID",
           "type": "string"
         }
       },
-      "required": ["category", "topic", "term"]
+      "required": ["name", "uuid"]
     },
     "location_keyword": {
       "title": "GMCD Location Keyword",


### PR DESCRIPTION
PR addressing these issues:
- Remove `mlhub:publications` in favor of `sci:publications` , replace any catalogs using `mlhub:publications` with that scientific extension property, and submit a PR to make scientific extension apply to catalogs as well
- Remove `mlhub:date_added` in favor of `created`
- Remove `mlhub:date_modified` in favor of `updated`
- Remove `mlhub:processing_level` in favor of `processing:level` from processing extension
- Keep `mlhub:creator_contact`
- Remove `mlhub:tags` in favor of `keywords` , and submit a PR to bring keywords into common metadata
- Follow up on request to expand common metadata to all STAC objects